### PR TITLE
add management of container_manage_cgroup selboolean

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,3 +3,4 @@ fixtures:
   repositories:
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib
     systemd: https://github.com/voxpupuli/puppet-systemd
+    selinux_core: https://github.com/puppetlabs/puppetlabs-selinux_core

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -34,6 +34,10 @@
 
 Main class for setting quadlet support
 
+* **See also**
+  * https://github.com/containers/podman/blob/main/docs/source/markdown/options/systemd.md
+    * container_manage_cgroup
+
 #### Examples
 
 ##### Set up Podman for quadlets
@@ -48,6 +52,7 @@ The following parameters are available in the `quadlets` class:
 
 * [`socket_enable`](#-quadlets--socket_enable)
 * [`create_quadlet_dir`](#-quadlets--create_quadlet_dir)
+* [`selinux_container_manage_cgroup`](#-quadlets--selinux_container_manage_cgroup)
 * [`purge_quadlet_dir`](#-quadlets--purge_quadlet_dir)
 
 ##### <a name="-quadlets--socket_enable"></a>`socket_enable`
@@ -63,6 +68,17 @@ Default value: `true`
 Data type: `Boolean`
 
 Should the directory for storing quadlet files be created.
+
+Default value: `false`
+
+##### <a name="-quadlets--selinux_container_manage_cgroup"></a>`selinux_container_manage_cgroup`
+
+Data type: `Boolean`
+
+If SELinux is enabled and this is true, set SELinux boolean
+'container_manage_cgroup' to true. Required if you want to run containers in
+systemd mode
+If SELinux is not enabled on system this does nothing.
 
 Default value: `false`
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,12 +17,10 @@ class quadlets::config (
       recurse => $purge_quadlet_dir,
     }
   }
-  if $facts['os']['selinux']['enabled'] {
-    if $selinux_container_manage_cgroup {
-      selboolean { 'container_manage_group':
-        persistent => true,
-        value      => on,
-      }
+  if $facts['os']['selinux']['enabled'] and $selinux_container_manage_cgroup {
+    selboolean { 'container_manage_group':
+      persistent => true,
+      value      => on,
     }
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,7 @@
 class quadlets::config (
   Boolean $create_quadlet_dir = $quadlets::create_quadlet_dir,
   Boolean $purge_quadlet_dir = $quadlets::purge_quadlet_dir,
+  Boolean $selinux_container_manage_cgroup = $quadlets::selinux_container_manage_cgroup,
 ) inherits quadlets {
   if $create_quadlet_dir {
     file { $quadlets::quadlet_dir:
@@ -14,6 +15,14 @@ class quadlets::config (
       purge   => $purge_quadlet_dir,
       force   => $purge_quadlet_dir,
       recurse => $purge_quadlet_dir,
+    }
+  }
+  if $facts['os']['selinux']['enabled'] {
+    if $selinux_container_manage_cgroup {
+      selboolean { 'container_manage_group':
+        persistent => true,
+        value      => on,
+      }
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,12 @@
 # @param socket_enable Should podman.socket be started and enabled
 # @param create_quadlet_dir Should the directory for storing quadlet files be created.
 #
+# @param selinux_container_manage_cgroup
+#   If SELinux is enabled and this is true, set SELinux boolean
+#   'container_manage_cgroup' to true. Required if you want to run containers in
+#   systemd mode
+#   If SELinux is not enabled on system this does nothing.
+#
 # @param purge_quadlet_dir
 #   Should the directory for storing quadlet files be purged. This has no effect
 #   unless create_quadlet_dir is set to true.
@@ -10,7 +16,9 @@
 # @example Set up Podman for quadlets
 #   include quadlets
 #
+# @see https://github.com/containers/podman/blob/main/docs/source/markdown/options/systemd.md container_manage_cgroup
 class quadlets (
+  Boolean $selinux_container_manage_cgroup = false,
   Boolean $socket_enable = true,
   Boolean $create_quadlet_dir = false,
   Boolean $purge_quadlet_dir = false,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add management of container_manage_cgroup if SELinux is enabled. This is required to run a container with the --systemd option on systems running SELinux.

https://github.com/containers/podman/blob/main/docs/source/markdown/options/systemd.md

#### This Pull Request (PR) fixes the following issues
#22 
