### PR TITLE
Make podman package management optional

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -50,11 +50,20 @@ include quadlets
 
 The following parameters are available in the `quadlets` class:
 
+* [`manage_package`](#-quadlets--manage_package)
 * [`manage_service`](#-quadlets--manage_service)
 * [`socket_enable`](#-quadlets--socket_enable)
 * [`create_quadlet_dir`](#-quadlets--create_quadlet_dir)
 * [`selinux_container_manage_cgroup`](#-quadlets--selinux_container_manage_cgroup)
 * [`purge_quadlet_dir`](#-quadlets--purge_quadlet_dir)
+
+##### <a name="-quadlets--manage_package"></a>`manage_package`
+
+Data type: `Boolean`
+
+Should podman package be installed by this module?
+
+Default value: `true`
 
 ##### <a name="-quadlets--manage_service"></a>`manage_service`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
 # @summary Main class for setting quadlet support
 #
+# @param manage_package Should podman package be installed by this module?
 # @param manage_service Should podman.socket service be managed by this module?
 # @param socket_enable Should podman.socket be started and enabled
 # @param create_quadlet_dir Should the directory for storing quadlet files be created.
@@ -20,6 +21,7 @@
 # @see https://github.com/containers/podman/blob/main/docs/source/markdown/options/systemd.md container_manage_cgroup
 class quadlets (
   Boolean $selinux_container_manage_cgroup = false,
+  Boolean $manage_package = true,
   Boolean $manage_service = true,
   Boolean $socket_enable = true,
   Boolean $create_quadlet_dir = false,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,12 @@
 # @summary Install podman software for quadlet support
 # @api private
 #
-class quadlets::install {
-  package { 'podman':
-    ensure => installed,
+class quadlets::install (
+  Boolean $manage_package = $quadlets::manage_package,
+) {
+  if $manage_package {
+    package { 'podman':
+      ensure => installed,
+    }
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,8 +10,6 @@ describe 'quadlets' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_class('quadlets') }
-        it { is_expected.to contain_class('quadlets::install') }
-        it { is_expected.to contain_package('podman').with_ensure('installed') }
         it { is_expected.to contain_service('podman.socket').with_ensure(true).with_enable(true) }
 
         case os_facts['os']['family']
@@ -19,6 +17,24 @@ describe 'quadlets' do
           it { is_expected.to contain_file('/etc/containers/systemd').with_ensure('directory') }
         else
           it { is_expected.not_to contain_file('/etc/containers/systemd') }
+        end
+
+        context 'with manage_package enabled' do
+          let(:params) do
+            { manage_package: true }
+          end
+
+          it { is_expected.to contain_class('quadlets::install') }
+          it { is_expected.to contain_package('podman').with_ensure('installed') }
+        end
+
+        context 'with manage_package disabled' do
+          let(:params) do
+            { manage_package: false }
+          end
+
+          it { is_expected.to contain_class('quadlets::install') }
+          it { is_expected.not_to contain_package('podman').with_ensure('installed') }
         end
 
         context 'with manage service enabled and socket enabled' do


### PR DESCRIPTION
#### Pull Request (PR) description

Allow the user to opt out of package management, to avoid conflicts when packages are managed elsewhere or when more attributes are necessary for the package.

#### This Pull Request (PR) fixes the following issues

```
Duplicate declaration: Package[podman] is already declared at ...
```
