### PR TITLE
Support rootless quadlets, add user option to quadlet

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,7 @@ class quadlets (
   Stdlib::CreateResources $quadlets_hash = {},
 ) {
   $quadlet_dir = '/etc/containers/systemd'
+  $quadlet_user_dir = '.config/containers/systemd'
 
   contain quadlets::install
   contain quadlets::config

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,0 +1,74 @@
+# @summary Generate and manage podman quadlet user
+#
+# @param user Specify user with options
+#
+# @example Run a CentOS user Container maning user, specifying home dir
+#   $_steve = {
+#     'name'          => 'steve',
+#     'create_dir'    => true,
+#     'manage_user'   => true,
+#     'manage_linger' => true,
+#     'homedir'       => '/nfs/home/steve',
+#   }
+#   quadlets::user { 'steve':
+#     user => $_steve,
+#   }
+#   quadlets::quadlet{ 'centos.container':
+#     ensure          => present,
+#     user            => $_steve,
+#     unit_entry     => {
+#      'Description' => 'Trivial Container that will be very lazy',
+#     },
+#     service_entry       => {
+#       'TimeoutStartSec' => '900',
+#     },
+#     container_entry => {
+#       'Image' => 'quay.io/centos/centos:latest',
+#       'Exec'  => 'sh -c "sleep inf"'
+#     },
+#     install_entry   => {
+#       'WantedBy' => 'default.target'
+#     },
+#     active          => true,
+#   }
+#
+define quadlets::user (
+  Quadlets::Quadlet_user $user,
+) {
+  include quadlets
+
+  $_username = $user['name']
+  $_file_group = pick($user['group'], $user['name'])
+  $_user_homedir = pick($user['homedir'], "/home/${user['name']}")
+  $_create_dir = pick($user['create_dir'], true)
+  $_manage_user = pick($user['manage_user'], true)
+  $_manage_linger = pick($user['manage_linger'], true)
+
+  if $_create_dir {
+    $components = split($quadlets::quadlet_user_dir, '/')
+    $dirs = $components.reduce([]) |$accum, $part| {
+      $accum + [$accum ? {
+          []      => "${_user_homedir}/${part}",
+          default => "${accum[-1]}/${part}"
+        }
+      ]
+    }
+    file { $dirs:
+      ensure => directory,
+      owner  => $_username,
+      group  => $_file_group,
+    }
+  }
+  if $_manage_user {
+    user { $_username:
+      ensure     => present,
+      home       => $_user_homedir,
+      managehome => true,
+    }
+  }
+  if $_manage_linger {
+    loginctl_user { $_username:
+      linger => enabled,
+    }
+  }
+}

--- a/spec/acceptance/user_container_spec.rb
+++ b/spec/acceptance/user_container_spec.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'quadlets::quadlet' do
+  context 'with a simple CentOS user container running' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+
+        # We might want to fall back on fuse-overlayfs
+        # rather than rely on overlay working.
+        #
+        package{'fuse-overlayfs':
+          ensure => present,
+          before => Quadlets::Quadlet['centos-user.container'],
+        }
+        # systemd-logind is masked on almalinux, enable it because it is needed
+        # for user containers
+        service{'systemd-logind.service':
+          ensure => true,
+          enable => true,
+        }
+        # begin hacks to make it work on rootless in rootless container
+        file_line{'containers_subgid':
+          path   => '/etc/subgid',
+          line   => 'containers:10000:5000',
+          before => User['containers'],
+        }
+        file_line{'containers_subuid':
+          path   => '/etc/subuid',
+          line   => 'containers:10000:5000',
+          before => User['containers'],
+        }
+        exec{'setcap_newgidmap':
+          command => '/usr/sbin/setcap cap_setgid=ep /usr/bin/newgidmap',
+          unless  => '/usr/sbin/getcap /usr/bin/newgidmap | grep -q cap_setgid=ep',
+          before  => User['containers'],
+        }
+        exec{'setcap_newuidmap':
+          command => '/usr/sbin/setcap cap_setuid=ep /usr/bin/newuidmap',
+          unless  => '/usr/sbin/getcap /usr/bin/newuidmap | grep -q cap_setuid=ep',
+          before  => User['containers'],
+        }
+        # end hacks to make it work on rootless in rootless container
+        $_containers = {
+          name => 'containers',
+        }
+        quadlets::user{'containers':
+          user => $_containers,
+        }
+        quadlets::quadlet{'centos-user.container':
+          ensure          => present,
+          user            => $_containers,
+          unit_entry      => {
+           'Description' => 'Trivial Container that will be very lazy',
+          },
+          service_entry   => {
+            'TimeoutStartSec' => '900',
+          },
+          container_entry => {
+            'Image'  => 'quay.io/centos/centos:latest',
+            'Exec'   => 'sh -c "sleep inf"',
+          },
+          install_entry   => {
+            'WantedBy' => 'default.target',
+          },
+          active          => true,
+        }
+        PUPPET
+      end
+    end
+
+    describe 'centos.service user unit' do
+      it 'is running' do
+        result = command('systemctl --user --machine containers@ is-active centos-user.service')
+        expect(result.stdout.strip).to eq('active')
+      end
+
+      it 'is enabled' do
+        result = command('systemctl --user --machine containers@ is-enabled centos-user.service')
+        expect(result.stdout.strip).to eq('generated')
+      end
+    end
+  end
+
+  context 'with 3 simple CentOS user containers of 2 different users running' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+
+        # We might want to fall back on fuse-overlayfs
+        # rather than rely on overlay working.
+        #
+        package{'fuse-overlayfs':
+          ensure => present,
+          before => [Quadlets::Quadlet['centos-user1.container'],Quadlets::Quadlet['centos-user2.container']],
+        }
+        # systemd-logind is masked on almalinux, enable it because it is needed
+        # for user containers
+        service{'systemd-logind.service':
+          ensure => true,
+          enable => true,
+        }
+        # begin hacks to make it work on rootless in rootless container
+        file_line{'containers_subgid':
+          path   => '/etc/subgid',
+          line   => 'containers:10000:5000',
+          before => User['containers'],
+        }
+        file_line{'containers_subuid':
+          path   => '/etc/subuid',
+          line   => 'containers:10000:5000',
+          before => User['containers'],
+        }
+        file_line{'steve_subgid':
+          path   => '/etc/subgid',
+          line   => 'steve:15000:5000',
+          before => User['steve'],
+        }
+        file_line{'steve_subuid':
+          path   => '/etc/subuid',
+          line   => 'steve:15000:5000',
+          before => User['steve'],
+        }
+        exec{'setcap_newgidmap':
+          command => '/usr/sbin/setcap cap_setgid=ep /usr/bin/newgidmap',
+          unless  => '/usr/sbin/getcap /usr/bin/newgidmap | grep -q cap_setgid=ep',
+          before  => [User['containers'],User['steve']],
+        }
+        exec{'setcap_newuidmap':
+          command => '/usr/sbin/setcap cap_setuid=ep /usr/bin/newuidmap',
+          unless  => '/usr/sbin/getcap /usr/bin/newuidmap | grep -q cap_setuid=ep',
+          before  => [User['containers'],User['steve']],
+        }
+        # end hacks to make it work on rootless in rootless container
+        user{'containers':
+          ensure     => present,
+          managehome => true,
+        }
+        loginctl_user{'containers':
+          linger  => enabled,
+        }
+        file{['/home/containers/.config', '/home/containers/.config/containers', '/home/containers/.config/containers/systemd']:
+          ensure => directory,
+          owner  => 'containers',
+          group  => 'containers',
+        }
+        $_containers = {
+          name => 'containers',
+        }
+        quadlets::quadlet{'centos-user1.container':
+          ensure          => present,
+          user            => $_containers,
+          unit_entry      => {
+           'Description' => 'Trivial First Container that will be very lazy',
+          },
+          service_entry   => {
+            'TimeoutStartSec' => '900',
+          },
+          container_entry => {
+            'Image'  => 'quay.io/centos/centos:latest',
+            'Exec'   => 'sh -c "sleep inf"',
+          },
+          install_entry   => {
+            'WantedBy' => 'default.target',
+          },
+          active          => true,
+        }
+        quadlets::quadlet{'centos-user2.container':
+          ensure          => present,
+          user            => $_containers,
+          unit_entry      => {
+           'Description' => 'Trivial Second Container that will be very lazy',
+          },
+          service_entry   => {
+            'TimeoutStartSec' => '900',
+          },
+          container_entry => {
+            'Image'  => 'quay.io/centos/centos:latest',
+            'Exec'   => 'sh -c "sleep inf"',
+          },
+          install_entry   => {
+            'WantedBy' => 'default.target',
+          },
+          active          => true,
+        }
+        file { ['/nfs', '/nfs/home']:
+          ensure => 'directory',
+        }
+        $_steve = {
+          'name'          => 'steve',
+          'create_dir'    => true,
+          'manage_user'   => true,
+          'manage_linger' => true,
+          'homedir'       => '/nfs/home/steve',
+        }
+        quadlets::user{'steve':
+          user => $_steve,
+        }
+        quadlets::quadlet{'centos-user3.container':
+          ensure          => present,
+          user            => $_steve,
+          unit_entry      => {
+           'Description' => 'Trivial Third Container that will be very lazy',
+          },
+          service_entry   => {
+            'TimeoutStartSec' => '900',
+          },
+          container_entry => {
+            'Image'  => 'quay.io/centos/centos:latest',
+            'Exec'   => 'sh -c "sleep inf"',
+          },
+          install_entry   => {
+            'WantedBy' => 'default.target',
+          },
+          active          => true,
+        }
+        PUPPET
+      end
+    end
+
+    describe 'centos.service user1 unit' do
+      it 'is running' do
+        result = command('systemctl --user --machine containers@ is-active centos-user1.service')
+        expect(result.stdout.strip).to eq('active')
+      end
+
+      it 'is enabled' do
+        result = command('systemctl --user --machine containers@ is-enabled centos-user1.service')
+        expect(result.stdout.strip).to eq('generated')
+      end
+    end
+
+    describe 'centos.service user2 unit' do
+      it 'is running' do
+        result = command('systemctl --user --machine containers@ is-active centos-user2.service')
+        expect(result.stdout.strip).to eq('active')
+      end
+
+      it 'is enabled' do
+        result = command('systemctl --user --machine containers@ is-enabled centos-user2.service')
+        expect(result.stdout.strip).to eq('generated')
+      end
+    end
+
+    describe 'centos.service user3 unit' do
+      it 'is running' do
+        result = command('systemctl --user --machine steve@ is-active centos-user3.service')
+        expect(result.stdout.strip).to eq('active')
+      end
+
+      it 'is enabled' do
+        result = command('systemctl --user --machine steve@ is-enabled centos-user3.service')
+        expect(result.stdout.strip).to eq('generated')
+      end
+    end
+  end
+end

--- a/templates/validate_cmd.epp
+++ b/templates/validate_cmd.epp
@@ -1,5 +1,6 @@
 <%|
   String[1] $quadlet,
+  Boolean $is_user,
 |%>
 /bin/bash -c '
     set -euo pipefail;
@@ -7,5 +8,5 @@
     quad=$d/<%= $quadlet %>;
     trap "rm $quad ; rmdir $d" EXIT;
     cp % $quad;
-    env QUADLET_UNIT_DIRS=$d /usr/lib/systemd/system-generators/podman-system-generator --dryrun
+    env QUADLET_UNIT_DIRS=$d <%= $is_user ? { true => '/usr/lib/systemd/user-generators/podman-user-generator', default => '/usr/lib/systemd/system-generators/podman-system-generator' } %> --dryrun
 '

--- a/types/quadlet_user.pp
+++ b/types/quadlet_user.pp
@@ -1,0 +1,10 @@
+# @summary custom datatype for container entries of podman container quadlet
+# @see https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html
+type Quadlets::Quadlet_user = Struct[
+  name => String[1],
+  Optional['group'] => String[1],
+  Optional['homedir'] => Stdlib::Unixpath,
+  Optional['create_dir'] => Boolean,
+  Optional['manage_user'] => Boolean,
+  Optional['manage_linger'] => Boolean,
+]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds `user` option to `quadlets::quadlet`

Example of managing a user and one of their quadlets:

```puppet
$_user_hash = {
     name          => 'santa',
     create_dir    => true,
     manage_user   => false,
     manage_linger => true,
     homedir       => "/home/santa",
}

quadlets::user { 'santa':
    user => $_user_hash,
 }

 quadlets::quadlet { "special.container":
    ensure          => present,
    unit_entry      => $unit_entry,
    container_entry => $container_entry,
    install_entry   => $install_entry,
    active          => true,
    user            => $_user_hash,
}
```

#### This Pull Request (PR) fixes the following issues
Fixes #19 

