### PR TITLE
Added location to drop ENC defined quadlets

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -64,6 +64,7 @@ The following parameters are available in the `quadlets` class:
 * [`create_quadlet_dir`](#-quadlets--create_quadlet_dir)
 * [`selinux_container_manage_cgroup`](#-quadlets--selinux_container_manage_cgroup)
 * [`purge_quadlet_dir`](#-quadlets--purge_quadlet_dir)
+* [`quadlets_hash`](#-quadlets--quadlets_hash)
 
 ##### <a name="-quadlets--manage_package"></a>`manage_package`
 
@@ -164,6 +165,14 @@ Should the directory for storing quadlet files be purged. This has no effect
 unless create_quadlet_dir is set to true.
 
 Default value: `false`
+
+##### <a name="-quadlets--quadlets_hash"></a>`quadlets_hash`
+
+Data type: `Stdlib::CreateResources`
+
+a `Hash` of quadlets to deploy
+
+Default value: `{}`
 
 ## Defined types
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,9 @@
 #   Should the directory for storing quadlet files be purged. This has no effect
 #   unless create_quadlet_dir is set to true.
 #
+# @param quadlets_hash a `Hash` of quadlets to deploy
+#
+#
 # @example Set up Podman for quadlets
 #   include quadlets
 #
@@ -38,6 +41,7 @@ class quadlets (
   String  $autoupdate_timer_name = 'podman-auto-update.timer',
   Boolean $create_quadlet_dir = false,
   Boolean $purge_quadlet_dir = false,
+  Stdlib::CreateResources $quadlets_hash = {},
 ) {
   $quadlet_dir = '/etc/containers/systemd'
 
@@ -46,4 +50,10 @@ class quadlets (
   contain quadlets::service
 
   Class['quadlets::install'] -> Class['quadlets::config'] -> Class['quadlets::service']
+
+  $quadlets_hash.each |$_n, $_v| {
+    quadlets::quadlet { $_n:
+      * => $_v,
+    }
+  }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -134,6 +134,55 @@ describe 'quadlets' do
             end
           end
         end
+
+        context 'with quadlets_hash param' do
+          context 'with quadlets_hash as default' do
+            it { is_expected.to have_quadlets__quadlet_resource_count(0) }
+          end
+
+          context 'with quadlets_hash defined' do
+            let(:params) do
+              { quadlets_hash: {
+                'centos.container': {
+                  'ensure' => 'present',
+                  'unit_entry' => {
+                    'Description' => 'Trivial Container that will be very lazy',
+                  },
+                  'service_entry' => {
+                    'TimeoutStartSec' => '900',
+                  },
+                  'container_entry' => {
+                    'Image' => 'quay.io/centos/centos:latest',
+                    'Exec' => 'sh -c "sleep inf"',
+                  },
+                  'install_entry' => {
+                    'WantedBy' => 'default.target',
+                  },
+                  'active' => true,
+                },
+                'almalinux.container': {
+                  'ensure' => 'present',
+                  'unit_entry' => {
+                    'Description' => 'Second Trivial Container',
+                  },
+                  'service_entry' => {
+                    'TimeoutStartSec' => '900',
+                  },
+                  'container_entry' => {
+                    'Image' => 'quay.io/almalinux/almalinux:latest',
+                    'Exec' => 'sh -c "sleep inf"',
+                  },
+                  'install_entry' => {
+                    'WantedBy' => 'default.target',
+                  },
+                  'active' => false,
+                },
+              } }
+            end
+
+            it { is_expected.to have_quadlets__quadlet_resource_count(2) }
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add a place to define quadlets via an ENC.

The `quadlets:quadlet` definition includes `quadlets`, so hanging off `init.pp` would create a loop.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
