### PR TITLE
Validate quadlet files before they are written

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -232,6 +232,7 @@ The following parameters are available in the `quadlets::quadlet` defined type:
 
 * [`quadlet`](#-quadlets--quadlet--quadlet)
 * [`ensure`](#-quadlets--quadlet--ensure)
+* [`validate_quadlet`](#-quadlets--quadlet--validate_quadlet)
 * [`mode`](#-quadlets--quadlet--mode)
 * [`active`](#-quadlets--quadlet--active)
 * [`unit_entry`](#-quadlets--quadlet--unit_entry)
@@ -259,6 +260,14 @@ Data type: `Enum['present', 'absent']`
 State of the container definition.
 
 Default value: `'present'`
+
+##### <a name="-quadlets--quadlet--validate_quadlet"></a>`validate_quadlet`
+
+Data type: `Boolean`
+
+Validate quadlet with `podman-system-generator --dryrun`
+
+Default value: `true`
 
 ##### <a name="-quadlets--quadlet--mode"></a>`mode`
 

--- a/spec/acceptance/bad_volume_spec.rb
+++ b/spec/acceptance/bad_volume_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'quadlets::quadlet' do
+  context 'with an invalid volume defintion' do
+    let(:manifest) do
+      <<-PUPPET
+      # This volume has a type but no Device so is invalid
+      # for "podman-system-generator"
+      quadlets::quadlet { 'bad.volume':
+        ensure       => present,
+        unit_entry   => {
+          'Description' => 'Bad Volume',
+        },
+        volume_entry => {
+         'VolumeName' => 'bad',
+         'Driver'     => 'local',
+         'Type'       => 'bind',
+        },
+      }
+      # And a good volume for comparison.
+      quadlets::quadlet { 'good.volume':
+        ensure       => present,
+        unit_entry   => {
+          'Description' => 'Good Volume',
+        },
+        volume_entry => {
+         'VolumeName' => 'good',
+         'Driver'     => 'local',
+         'Device'     => '/srv/good',
+         'Type'       => 'bind',
+        },
+      }
+
+      PUPPET
+    end
+
+    it 'applies with failures (as expected)' do
+      res = apply_manifest(manifest, expect_failures: true)
+      expect(res.stderr + res.stdout).to match(%r{converting "bad.volume": key Type can't be used without Device})
+    end
+
+    describe file('/etc/containers/systemd/bad.volume') {
+      it { is_expected.not_to exist }
+    }
+    describe file('/etc/containers/systemd/good.volume') {
+      it { is_expected.to exist }
+    }
+  end
+end

--- a/spec/defines/quadlet_spec.rb
+++ b/spec/defines/quadlet_spec.rb
@@ -43,7 +43,8 @@ describe 'quadlets::quadlet' do
             with_content(%r{^Image=quay.io/centos/centos:latest$}).
             with_content(%r{^PublishPort=1234$}).
             with_content(%r{^PublishPort=123.1.1.1:100:102$}).
-            with_content(%r{^Exec=sh -c "sleep inf"$})
+            with_content(%r{^Exec=sh -c "sleep inf"$}).
+            with_validate_cmd(%r{quad=\$d/centos.container})
         }
 
         it { is_expected.to contain_systemd__daemon_reload('centos.container') }
@@ -65,6 +66,14 @@ describe 'quadlets::quadlet' do
 
           it { is_expected.to contain_file('/etc/containers/systemd/centos.container').with_ensure('absent') }
           it { is_expected.to contain_systemd__daemon_reload('centos.container') }
+        end
+
+        context 'with the validate_quadlet false' do
+          let(:params) do
+            super().merge({ validate_quadlet: false })
+          end
+
+          it { is_expected.to contain_file('/etc/containers/systemd/centos.container').without_validate_cmd }
         end
       end
     end

--- a/templates/validate_cmd.epp
+++ b/templates/validate_cmd.epp
@@ -1,0 +1,11 @@
+<%|
+  String[1] $quadlet,
+|%>
+/bin/bash -c '
+    set -euo pipefail;
+    d=$(mktemp -d);
+    quad=$d/<%= $quadlet %>;
+    trap "rm $quad ; rmdir $d" EXIT;
+    cp % $quad;
+    env QUADLET_UNIT_DIRS=$d /usr/lib/systemd/system-generators/podman-system-generator --dryrun
+'


### PR DESCRIPTION
#### Pull Request (PR) description

Validate quadlet files before they are written.

Currently a quadlet file is written to `/etc/containers/systemd` before being processed asynchronsly by the call to `systemd daemon-reload` and the generator.

Validate the quadlet files before they are written.

Result of an invalid quadlet:

```
Error: Execution of '
/bin/bash -c '
    set -euo pipefail;
    d=$(mktemp -d /tmp/validate.XXXXXX);
    quad=$d/bad.volume;
    trap "rm $quad ; rmdir $d" EXIT;
    cp /etc/containers/systemd/bad.volume20250921-6073-1p7uxs5 $quad;
    env QUADLET_UNIT_DIRS=$d /usr/lib/systemd/system-generators/podman-system-generator --dryrun
'
' returned 1: quadlet-generator[6202]: Loading source unit file /tmp/validate.9ldXe2/bad.volume
quadlet-generator[6202]: converting "bad.volume": key Type can't be used without Device
Error: /Stage[main]/Main/Quadlets::Quadlet[bad.volume]/File[/etc/containers/systemd/bad.volume]/ensure: change from 'absent' to 'present' failed: Execution of '
/bin/bash -c '
    set -euo pipefail;
    d=$(mktemp -d /tmp/validate.XXXXXX);
    quad=$d/bad.volume;
    trap "rm $quad ; rmdir $d" EXIT;
    cp /etc/containers/systemd/bad.volume20250921-6073-1p7uxs5 $quad;
    env QUADLET_UNIT_DIRS=$d /usr/lib/systemd/system-generators/podman-system-generator --dryrun
'
' returned 1: quadlet-generator[6202]: Loading source unit file /tmp/validate.9ldXe2/bad.volume
quadlet-generator[6202]: converting "bad.volume": key Type can't be used without Device
Notice: /Stage[main]/Main/Quadlets::Quadlet[bad.volume]/Systemd::Daemon_reload[bad.volume]/Exec[systemd-bad.volume-systemctl-daemon-reload]: Dependency File[/etc/containers/systemd/bad.volume] has failures: true
Warning: /Stage[main]/Main/Quadlets::Quadlet[bad.volume]/Systemd::Daemon_reload[bad.volume]/Exec[systemd-bad.volume-systemctl-daemon-reload]: Skipping because of failed dependencies
Notice: Applied catalog in 0.38 seconds
```

A new option `validate_quadlet` can be set `false` to disable this validation.

