### PR TITLE
Allow Pods with PublishPort = 8080:80

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -688,7 +688,7 @@ Struct[Optional['ContainersConfModule'] => Variant[Stdlib::Unixpath,Array[Stdlib
   Optional['Network']              => String[1],
   Optional['PodmanArgs']           => Variant[String[1],Array[String[1]]],
   Optional['PodName']              => String[1],
-  Optional['PublishPort']          => Array[Stdlib::Port,1],
+  Optional['PublishPort']          => Array[Variant[Stdlib::Port,String[1]],1],
   Optional['Volume']               => Variant[String[1],Array[String[1],]]]
 ```
 

--- a/spec/type_aliases/unit_container_spec.rb
+++ b/spec/type_aliases/unit_container_spec.rb
@@ -7,6 +7,8 @@ describe 'Quadlets::Unit::Container' do
   it { is_expected.to allow_value({ 'PublishPort' => [1234] }) }
   it { is_expected.to allow_value({ 'PublishPort' => ['1234-12346'] }) }
   it { is_expected.to allow_value({ 'PublishPort' => [1234, '123.111.1.1:55:72'] }) }
+  it { is_expected.to allow_value({ 'PublishPort' => ['1234:5678'] }) }
+  it { is_expected.not_to allow_value({ 'PublishPort' => '1234:5678' }) }
   it { is_expected.to allow_value({ 'Entrypoint' => 'python3' }) }
   it { is_expected.to allow_value({ 'Entrypoint' => '["/usr/bin/sleep", "inf"]' }) }
   it { is_expected.to allow_value({ 'Exec'  => '/bin/bash' }) }

--- a/spec/type_aliases/unit_kube_spec.rb
+++ b/spec/type_aliases/unit_kube_spec.rb
@@ -6,6 +6,8 @@ describe 'Quadlets::Unit::Kube' do
   it { is_expected.to allow_value({ 'Yaml' => '/path/to/yaml/file' }) }
   it { is_expected.to allow_value({ 'PublishPort' => ['1234-12346'] }) }
   it { is_expected.to allow_value({ 'PublishPort' => [1234, '123.111.1.1:23:56'] }) }
+  it { is_expected.to allow_value({ 'PublishPort' => ['1234:5678'] }) }
+  it { is_expected.not_to allow_value({ 'PublishPort' => '1234:5678' }) }
   it { is_expected.to allow_value({ 'ConfigMap' => ['/path/to/configmap.yaml'] }) }
   it { is_expected.to allow_value({ 'Network' => ['host'] }) }
   it { is_expected.to allow_value({ 'KubeDownForce' => true }) }

--- a/spec/type_aliases/unit_pod_spec.rb
+++ b/spec/type_aliases/unit_pod_spec.rb
@@ -4,4 +4,6 @@ require 'spec_helper'
 
 describe 'Quadlets::Unit::Pod' do
   it { is_expected.to allow_value({ 'PodName' => 'special' }) }
+  it { is_expected.to allow_value({ 'PublishPort' => ['1234:5678'] }) }
+  it { is_expected.not_to allow_value({ 'PublishPort' => '1234:5678' }) }
 end

--- a/types/unit/pod.pp
+++ b/types/unit/pod.pp
@@ -6,6 +6,6 @@ type Quadlets::Unit::Pod = Struct[
   Optional['Network']              => String[1],
   Optional['PodmanArgs']           => Variant[String[1],Array[String[1]]],
   Optional['PodName']              => String[1],
-  Optional['PublishPort']          => Array[Stdlib::Port,1],
+  Optional['PublishPort']          => Array[Variant[Stdlib::Port,String[1]],1],
   Optional['Volume']               => Variant[String[1],Array[String[1],]],
 ]


### PR DESCRIPTION
#### Pull Request (PR) description

While containers and kubes both allowed a `PublishPort` of `hostPort:containerPort` pods did not.

* https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#id15

