### PR TITLE
Allow pods to define a labels

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -689,7 +689,8 @@ Struct[Optional['ContainersConfModule'] => Variant[Stdlib::Unixpath,Array[Stdlib
   Optional['PodmanArgs']           => Variant[String[1],Array[String[1]]],
   Optional['PodName']              => String[1],
   Optional['PublishPort']          => Array[Stdlib::Port,1],
-  Optional['Volume']               => Variant[String[1],Array[String[1],]]]
+  Optional['Volume']               => Variant[String[1],Array[String[1],]],
+  Optional['Label']                => Variant[String[1],Array[String[1],1]]]
 ```
 
 ### <a name="Quadlets--Unit--Unit"></a>`Quadlets::Unit::Unit`

--- a/spec/type_aliases/unit_pod_spec.rb
+++ b/spec/type_aliases/unit_pod_spec.rb
@@ -4,4 +4,6 @@ require 'spec_helper'
 
 describe 'Quadlets::Unit::Pod' do
   it { is_expected.to allow_value({ 'PodName' => 'special' }) }
+  it { is_expected.to allow_value({ 'Label' => ['abc','xyz'] }) }
+  it { is_expected.to allow_value({ 'Label' => 'xyz' }) }
 end

--- a/types/unit/pod.pp
+++ b/types/unit/pod.pp
@@ -8,4 +8,5 @@ type Quadlets::Unit::Pod = Struct[
   Optional['PodName']              => String[1],
   Optional['PublishPort']          => Array[Stdlib::Port,1],
   Optional['Volume']               => Variant[String[1],Array[String[1],]],
+  Optional['Label']                => Variant[String[1],Array[String[1],1]],
 ]


### PR DESCRIPTION
#### This Pull Request (PR) fixes the following issues

Pod quadlets can specify a label

* https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#pod-units-pod


