### PR TITLE
Correct Hostname to HostName

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -543,7 +543,7 @@ Struct[Optional['AddCapability'] => Array[String[1],1],
   Optional['HealthStartupInterval'] => Variant[Enum['disable'],Integer[0]],
   Optional['HealthStartupTimeout'] => String[1],
   Optional['HealthTimeout'] => String[1],
-  Optional['HostName'] => String[1],
+  Optional['HostName'] => Variant[String[1],Array[String[1],1]],
   Optional['Image'] => String[1],
   Optional['IP'] => Stdlib::IP::Address::V4,
   Optional['IP6'] => Stdlib::IP::Address::V6,
@@ -588,8 +588,7 @@ Struct[Optional['AddCapability'] => Array[String[1],1],
   Optional['User'] => Variant[String[1],Integer[0]],
   Optional['UserNS'] => String[1],
   Optional['Volume'] => Array[String[1],0],
-  Optional['WorkingDir'] => Stdlib::Unixpath,
-  Optional['Hostname'] => Variant[Stdlib::Fqdn,Array[Stdlib::Fqdn,1]]]
+  Optional['WorkingDir'] => Stdlib::Unixpath]
 ```
 
 ### <a name="Quadlets--Unit--Image"></a>`Quadlets::Unit::Image`
@@ -691,7 +690,7 @@ Struct[Optional['ContainersConfModule'] => Variant[Stdlib::Unixpath,Array[Stdlib
   Optional['PodName']              => String[1],
   Optional['PublishPort']          => Array[Variant[Stdlib::Port,String[1]],1],
   Optional['Volume']               => Variant[String[1],Array[String[1],]],
-  Optional['Hostname']             => Variant[Stdlib::Fqdn,Array[Stdlib::Fqdn,1]],
+  Optional['HostName']             => Variant[String[1],Array[String[1],1]],
   Optional['Label']                => Variant[String[1],Array[String[1],1]]]
 ```
 

--- a/spec/type_aliases/unit_container_spec.rb
+++ b/spec/type_aliases/unit_container_spec.rb
@@ -13,6 +13,6 @@ describe 'Quadlets::Unit::Container' do
   it { is_expected.to allow_value({ 'Entrypoint' => '["/usr/bin/sleep", "inf"]' }) }
   it { is_expected.to allow_value({ 'Exec'  => '/bin/bash' }) }
   it { is_expected.to allow_value({ 'Exec'  => './entrypoint.sh' }) }
-  it { is_expected.to allow_value({ 'Hostname' => ['foo.example.net'] }) }
-  it { is_expected.to allow_value({ 'Hostname' => 'foo.example.net' }) }
+  it { is_expected.to allow_value({ 'HostName' => ['foo.example.net'] }) }
+  it { is_expected.to allow_value({ 'HostName' => 'foo.example.net' }) }
 end

--- a/spec/type_aliases/unit_pod_spec.rb
+++ b/spec/type_aliases/unit_pod_spec.rb
@@ -4,8 +4,8 @@ require 'spec_helper'
 
 describe 'Quadlets::Unit::Pod' do
   it { is_expected.to allow_value({ 'PodName' => 'special' }) }
-  it { is_expected.to allow_value({ 'Hostname' => ['foo.example.net'] }) }
-  it { is_expected.to allow_value({ 'Hostname' => 'foo.example.net' }) }
+  it { is_expected.to allow_value({ 'HostName' => ['foo.example.net'] }) }
+  it { is_expected.to allow_value({ 'HostName' => 'foo.example.net' }) }
   it { is_expected.to allow_value({ 'Label' => %w[abc xyz] }) }
   it { is_expected.to allow_value({ 'Label' => 'xyz' }) }
   it { is_expected.to allow_value({ 'PublishPort' => ['1234:5678'] }) }

--- a/types/unit/container.pp
+++ b/types/unit/container.pp
@@ -31,7 +31,7 @@ type Quadlets::Unit::Container = Struct[
   Optional['HealthStartupInterval'] => Variant[Enum['disable'],Integer[0]],
   Optional['HealthStartupTimeout'] => String[1],
   Optional['HealthTimeout'] => String[1],
-  Optional['HostName'] => String[1],
+  Optional['HostName'] => Variant[String[1],Array[String[1],1]],
   Optional['Image'] => String[1],
   Optional['IP'] => Stdlib::IP::Address::V4,
   Optional['IP6'] => Stdlib::IP::Address::V6,
@@ -77,5 +77,4 @@ type Quadlets::Unit::Container = Struct[
   Optional['UserNS'] => String[1],
   Optional['Volume'] => Array[String[1],0],
   Optional['WorkingDir'] => Stdlib::Unixpath,
-  Optional['Hostname'] => Variant[Stdlib::Fqdn,Array[Stdlib::Fqdn,1]],
 ]

--- a/types/unit/pod.pp
+++ b/types/unit/pod.pp
@@ -8,6 +8,6 @@ type Quadlets::Unit::Pod = Struct[
   Optional['PodName']              => String[1],
   Optional['PublishPort']          => Array[Variant[Stdlib::Port,String[1]],1],
   Optional['Volume']               => Variant[String[1],Array[String[1],]],
-  Optional['Hostname']             => Variant[Stdlib::Fqdn,Array[Stdlib::Fqdn,1]],
+  Optional['HostName']             => Variant[String[1],Array[String[1],1]],
   Optional['Label']                => Variant[String[1],Array[String[1],1]],
 ]


### PR DESCRIPTION
#### Pull Request (PR) description

A bug was introduced in https://github.com/voxpupuli/puppet-quadlets/pull/59

The correct attribute for Containers and Pods is `HostName` and not `Hostname`

In addition it was already established that `Stdlib::Fqdn` was too restrictive for `HostName`.

Resolves:

```
Error: /Stage[main]/Hg_wlcghammercloud::Private_podman::Setup/Quadlets::Quadlet[hammercloud.pod]/File[/var/lib/hcman/.config/containers/systemd/hammercloud.po
d]/ensure: change from 'absent' to 'present' failed: Execution of '                                                                                           
/bin/bash -c '                                                                                                                                                
    set -euo pipefail;                                                                                                                                        
    d=$(mktemp -d);                                                                                                                                           
    quad=$d/hammercloud.pod;                                                                                                                                  
    trap "rm $quad ; rmdir $d" EXIT;                                                                                                                          
    cp /var/lib/hcman/.config/containers/systemd/hammercloud.pod20251017-19435-1y2wmn4 $quad;                                                                 
    env QUADLET_UNIT_DIRS=$d /usr/lib/systemd/user-generators/podman-user-generator --dryrun                                                                  
'                                                                                                                                                             
' returned 1: quadlet-generator[20300]: Loading source unit file /tmp/tmp.liFODB7UKH/hammercloud.pod                                                          
quadlet-generator[20300]: converting "hammercloud.pod": unsupported key 'Hostname' in group 'Pod' in /tmp/tmp.liFODB7UKH/hammercloud.pod    
```
Nice to see the validation trip though.

* https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html
