### PR TITLE
Validate new quadlet with existing quadlets

### DIFF
--- a/spec/acceptance/container_in_pod_spec.rb
+++ b/spec/acceptance/container_in_pod_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'quadlets::quadlet' do
+  context 'with a container in a pod' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+
+        # We might want to fall back on fuse-overlayfs
+        # rather than rely on overlay working.
+        #
+        package{'fuse-overlayfs':
+          ensure => present,
+          before => Quadlets::Quadlet['podcentos.pod'],
+        }
+
+        quadlets::quadlet{'podcentos.pod':
+          ensure => present,
+          unit_entry     => {
+            'Description' => 'Trivial Pod',
+          },
+          pod_entry      => {
+            # work-around for https://github.com/voxpupuli/beaker-docker/issues/171
+            'PodmanArgs' => '--infra-image=registry.k8s.io/pause:3.9',
+          },
+          active          => true,
+        }
+
+        quadlets::quadlet{'podcentos.container':
+          ensure          => present,
+          unit_entry     => {
+           'Description' => 'Trivial Container in the Pod above',
+          },
+          service_entry       => {
+            'TimeoutStartSec' => '900',
+          },
+          container_entry => {
+            'Image'  => 'quay.io/centos/centos:latest',
+            'Exec'   => 'sh -c "sleep inf"',
+            'Pod'    => 'podcentos.pod',
+          },
+          install_entry   => {
+            'WantedBy' => 'default.target',
+          },
+          active          => true,
+          # This will not validate unless pod is on disk.
+          require         => Quadlets::Quadlet['podcentos.pod'],
+        }
+        PUPPET
+      end
+    end
+
+    %w[podcentos.service podcentos-pod.service].each do |svc|
+      describe service(svc) do
+        it { is_expected.to be_running }
+        it { is_expected.to be_enabled }
+      end
+    end
+  end
+end

--- a/templates/validate_cmd.epp
+++ b/templates/validate_cmd.epp
@@ -1,12 +1,15 @@
 <%|
   String[1] $quadlet,
   Boolean $is_user,
+  String[1] $dest,
 |%>
 /bin/bash -c '
     set -euo pipefail;
     d=$(mktemp -d);
     quad=$d/<%= $quadlet %>;
-    trap "rm $quad ; rmdir $d" EXIT;
+    existing=(<%= $dest %>/*)
+    ((${#existing[@]})) && cp -- "${existing[@]}" $d/.
+    trap "rm $d/* ; rmdir $d" EXIT;
     cp % $quad;
     env QUADLET_UNIT_DIRS=$d <%= $is_user ? { true => '/usr/lib/systemd/user-generators/podman-user-generator', default => '/usr/lib/systemd/system-generators/podman-system-generator' } %> --dryrun
 '


### PR DESCRIPTION
#### Pull Request (PR) description

When a quadlet is validated it must be done so with knowledge of all the other existing quadlets on the system. Currently each quadlet is validated in isolation.

Example:

```puppet
quadlets::quadlet{'podcentos.pod':
  ensure => present,
  install_entry   => {
   'WantedBy' => 'default.target',
  },
  active          => true,
}
quadlets::quadlet{'podcentos.container':
  ensure          => present,
  container_entry => {
   'Pod'    => 'podcentos.pod',
   'Image'  => 'quay.io/centos/centos:latest',
   'Exec'   => 'sh -c "sleep inf"',
  },
  install_entry   => {
   'WantedBy' => 'default.target',
  },
  active          => true,
  # pod must be on disk first
  require         => Quadlets::Quadlet['podcentos.pod'],
}
```

Will fail with

```
quadlet-generator[32679]: converting "podcentos.container": quadlet pod unit podcentos.pod does not exist
```
