### PR TITLE
Correct name of image services

### DIFF
--- a/manifests/quadlet.pp
+++ b/manifests/quadlet.pp
@@ -120,47 +120,46 @@ define quadlets::quadlet (
   $_split = $quadlet.split('[.]')
   $_name = $_split[0]
   $_type = $_split[1]
-  # Validate the input and find the service name.
+  # Validate the input
   case $_type {
     'container': {
       if $volume_entry or $pod_entry or $image_entry or $network_entry {
         fail('A volume_entry, pod_entry, image_entry or network_entry makes no sense on a container quadlet')
       }
-      $_service = "${_name}.service"
     }
     'volume': {
       if $container_entry or $pod_entry or $kube_entry or $image_entry or $network_entry {
         fail('A container_entry, pod_entry, kube_entry, network_entry or image_entry makes no sense on a volume quadlet')
       }
-      $_service = "${_name}-volume.service"
     }
     'network': {
       if $container_entry or $pod_entry or $kube_entry or $image_entry or $volume_entry {
         fail('A container_entry, pod_entry, volume_entry, image_entry or kube_entry makes no sense on a network quadlet')
       }
-      $_service = "${_name}-network.service"
     }
     'pod': {
       if $container_entry or $volume_entry or $kube_entry or $image_entry or $network_entry {
         fail('A container_entry, volume_entry, kube_entry, network_entry or image_entry makes no sense on a pod quadlet')
       }
-      $_service = "${_name}-pod.service"
     }
     'kube': {
       if $volume_entry or $pod_entry or $container_entry or $image_entry or $network_entry {
         fail('A container_entry, pod_entry, volume_entry, network_entry  or image_entry makes no sense on a kube quadlet')
       }
-      $_service = "${_name}.service"
     }
     'image': {
       if $volume_entry or $pod_entry or $container_entry or $kube_entry or $network_entry {
         fail('A container_entry, pod_entry, volume_entry, network_entry or kube_entry makes no sense on an image quadlet')
       }
-      $_service = "${_name}.service"
     }
     default: {
       fail('Should never be here due to typing on quadlet')
     }
+  }
+
+  $_service = $_type in ['container','kube'] ? {
+    true    => "${_name}.service",
+    default => "${_name}-${_type}.service",
   }
 
   include quadlets

--- a/spec/acceptance/image_spec.rb
+++ b/spec/acceptance/image_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'quadlets::quadlet' do
+  context 'with a simple busybox image to download' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<-PUPPET
+
+        quadlets::quadlet{'busybox.image':
+          ensure          => present,
+          unit_entry     => {
+           'Description' => 'Download the busybox image',
+          },
+          service_entry       => {
+            'TimeoutStartSec' => '900',
+          },
+          image_entry => {
+            'Image'  => 'docker.io/busybox',
+          },
+          install_entry   => {
+            'WantedBy' => 'default.target',
+          },
+          active          => true,
+        }
+        PUPPET
+      end
+    end
+
+    describe service('busybox-image.service') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+  end
+end

--- a/spec/acceptance/kube_spec.rb
+++ b/spec/acceptance/kube_spec.rb
@@ -39,9 +39,9 @@ describe 'quadlets::quadlet' do
         }
         package{'fuse-overlayfs':
           ensure => present,
-          before => Quadlets::Quadlet['centos.kube'],
+          before => Quadlets::Quadlet['kubeycentos.kube'],
         }
-        quadlets::quadlet{'centos.kube':
+        quadlets::quadlet{'kubeycentos.kube':
           ensure          => present,
           kube_entry     => {
            'Yaml' => '/etc/containers/yaml/pod.yaml',
@@ -58,7 +58,7 @@ describe 'quadlets::quadlet' do
       end
     end
 
-    describe service('centos.service') do
+    describe service('kubeycentos.service') do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end

--- a/spec/defines/quadlet_spec.rb
+++ b/spec/defines/quadlet_spec.rb
@@ -78,6 +78,38 @@ describe 'quadlets::quadlet' do
           it { is_expected.to contain_file('/etc/containers/systemd/centos.container').without_validate_cmd }
         end
       end
+
+      context 'with a kube quadlet' do
+        let(:title) { 'magic.kube' }
+        let(:params) do
+          {
+            ensure: 'present',
+            unit_entry: {
+              'Description' => 'Simple magic kube',
+            },
+            active: true,
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/containers/systemd/magic.kube') }
+        it { is_expected.to contain_service('magic.service').with_ensure(true) }
+      end
+
+      context 'with an image quadlet' do
+        let(:title) { 'busybox.image' }
+        let(:params) do
+          {
+            ensure: 'present',
+            unit_entry: {
+              'Description' => 'Simple busybox image',
+            },
+            active: true,
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/containers/systemd/busybox.image') }
+        it { is_expected.to contain_service('busybox-image.service').with_ensure(true) }
+      end
     end
   end
 end

--- a/spec/type_aliases/unit_network_spec.rb
+++ b/spec/type_aliases/unit_network_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'spec_helper'
+
 describe 'Quadlets::Unit::Network' do
   it { is_expected.to allow_value({ 'ContainersConfModule' => '/etc/container/1.conf' }) }
   it { is_expected.to allow_value({ 'DisableDNS'           => true }) }


### PR DESCRIPTION
#### Pull Request (PR) description

The service names for  `beta.image` is `beta-image.service`.

Before this patch they had been configured as  `beta.service`. Only containers and kubes follow the pattern of `name.kube` or `name.container` to `name.service`
