### PR TITLE
Allow to configure UserNS mode on Pods

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -689,6 +689,7 @@ Struct[Optional['ContainersConfModule'] => Variant[Stdlib::Unixpath,Array[Stdlib
   Optional['PodmanArgs']           => Variant[String[1],Array[String[1]]],
   Optional['PodName']              => String[1],
   Optional['PublishPort']          => Array[Variant[Stdlib::Port,String[1]],1],
+  Optional['UserNS']               => String[1],
   Optional['Volume']               => Variant[String[1],Array[String[1],]],
   Optional['HostName']             => Variant[String[1],Array[String[1],1]],
   Optional['Label']                => Variant[String[1],Array[String[1],1]]]

--- a/spec/type_aliases/unit_pod_spec.rb
+++ b/spec/type_aliases/unit_pod_spec.rb
@@ -10,4 +10,5 @@ describe 'Quadlets::Unit::Pod' do
   it { is_expected.to allow_value({ 'Label' => 'xyz' }) }
   it { is_expected.to allow_value({ 'PublishPort' => ['1234:5678'] }) }
   it { is_expected.not_to allow_value({ 'PublishPort' => '1234:5678' }) }
+  it { is_expected.to allow_value({ 'UserNS' => 'auto' }) }
 end

--- a/types/unit/pod.pp
+++ b/types/unit/pod.pp
@@ -7,6 +7,7 @@ type Quadlets::Unit::Pod = Struct[
   Optional['PodmanArgs']           => Variant[String[1],Array[String[1]]],
   Optional['PodName']              => String[1],
   Optional['PublishPort']          => Array[Variant[Stdlib::Port,String[1]],1],
+  Optional['UserNS']               => String[1],
   Optional['Volume']               => Variant[String[1],Array[String[1],]],
   Optional['HostName']             => Variant[String[1],Array[String[1],1]],
   Optional['Label']                => Variant[String[1],Array[String[1],1]],


### PR DESCRIPTION


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

When using Pods, the UserNS configuration on the container is ignored:

https://docs.podman.io/en/latest/markdown/podman-run.1.html#userns-mode

https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#id21

This allows to set a UserNS on the pod level, which is then used by the container.

#### This Pull Request (PR) fixes the following issues

None
