### PR TITLE
Explicitly create the group of quadlet user

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -517,7 +517,7 @@ Default value: `true`
 
 Data type: `Boolean`
 
-If true the user will be created.
+If true the user and group will be created.
 
 Default value: `true`
 

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -4,7 +4,7 @@
 # @param group Specify group ownership of quadlet directories, if `undef` it will be set equal to the username.
 # @param homedir Home directory, if `undef` `/home/$user` will be used.
 # @param create_dir If true the directory for containers will be created at `$homedir/.config/contaners/systemd`.
-# @param manage_user If true the user will be created.
+# @param manage_user If true the user and group will be created.
 # @param manage_linger If true `systemd --user` will be started for user.
 #
 # @example Run a CentOS user Container maning user, specifying home dir
@@ -64,8 +64,11 @@ define quadlets::user (
     }
   }
   if $manage_user {
+    group { $_file_group: }
+
     user { $user:
       ensure     => present,
+      gid        => $_file_group,
       home       => $_user_homedir,
       managehome => true,
     }

--- a/spec/acceptance/user_spec.rb
+++ b/spec/acceptance/user_spec.rb
@@ -11,12 +11,14 @@ describe 'quadlets::user' do
           manage_linger => false,
         }
 
+        quadlets::user{'grpuser':
+          group         => 'grpgrp',
+          manage_linger => false,
+        }
+
         user{ 'nomanage':
           home       => '/opt/nomanage',
           managehome => true,
-        }
-        $_nomanage = {
-          name          => 'nomanage',
         }
         quadlets::user{ 'nomanage':
           manage_user   => false,
@@ -35,6 +37,18 @@ describe 'quadlets::user' do
     describe file('/home/simple/.config/containers/systemd') do
       it { is_expected.to be_directory }
       it { is_expected.to be_owned_by 'simple' }
+      it { is_expected.to be_grouped_into 'simple' }
+    end
+
+    describe user('grpuser') do
+      it { is_expected.to exist }
+      it { is_expected.to belong_to_primary_group 'grpgrp' }
+    end
+
+    describe file('/home/grpuser/.config/containers/systemd') do
+      it { is_expected.to be_directory }
+      it { is_expected.to be_owned_by 'grpuser' }
+      it { is_expected.to be_grouped_into 'grpgrp' }
     end
 
     describe file('/opt/nomanage/.config/containers/systemd') do

--- a/spec/defines/user_spec.rb
+++ b/spec/defines/user_spec.rb
@@ -5,15 +5,47 @@ require 'spec_helper'
 describe 'quadlets::user' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts }
+      let(:facts) do
+        os_facts
+      end
 
-      context 'with a simple user image' do
+      context 'with a simple user' do
         let(:title) { 'nano' }
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_user('nano') }
-        it { is_expected.to contain_user('nano').with_foo }
         it { is_expected.to contain_loginctl_user('nano').with_linger('enabled') }
+
+        it {
+          is_expected.to contain_file('/home/nano/.config/containers/systemd').with(
+            {
+              ensure: 'directory',
+              owner: 'nano',
+              group: 'nano',
+            }
+          )
+        }
+      end
+
+      context 'with a simple user and group' do
+        let(:title) { 'pico' }
+        let(:params) do
+          { 'group' => 'giga' }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_user('pico').with_gid('giga') }
+        it { is_expected.to contain_loginctl_user('pico').with_linger('enabled') }
+
+        it {
+          is_expected.to contain_file('/home/pico/.config/containers/systemd').with(
+            {
+              ensure: 'directory',
+              owner: 'pico',
+              group: 'giga',
+            }
+          )
+        }
       end
 
       context 'with a simple user actions disabled' do
@@ -30,6 +62,7 @@ describe 'quadlets::user' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.not_to contain_user('micro') }
         it { is_expected.not_to contain_loginctl_user('micro') }
+        it { is_expected.not_to contain_file('/home/mirco/.config/containers/systemd') }
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description

While the group ownership of the quadlet files was being specified the group was not being created.
