### PR TITLE
Find existing quadlets more precisely

### DIFF
--- a/templates/validate_cmd.epp
+++ b/templates/validate_cmd.epp
@@ -7,7 +7,7 @@
     set -euo pipefail;
     d=$(mktemp -d);
     quad=$d/<%= $quadlet %>;
-    existing=(<%= $dest %>/*)
+    existing=(<%= $dest %>/*.*)
     ((${#existing[@]})) && cp -- "${existing[@]}" $d/.
     trap "rm $d/* ; rmdir $d" EXIT;
     cp % $quad;


### PR DESCRIPTION
#### Pull Request (PR) description

During validation of a new quadlet the existing quadlet must be copied to an ephemeral directory.

This could fail with:

```
cp: -r not specified; omitting directory '/etc/containers/systemd/users'
```

The extra directory should not be copied. The files to be copied  with be of the form  `my.pod`, `my.container`, ...

Particularly on Ubuntu and Debian the directory `/etc/containers/systemd/users` exists to store system provided user quadlets and that directory should be ignored.

Change is:
```
echo /etc/containers/systemd/*
/etc/containers/systemd/busybox.image /etc/containers/systemd/centos.container /etc/containers/systemd/good.volume /etc/containers/systemd/kubeycentos.kube /etc/containers/systemd/podcentos.pod /etc/containers/systemd/users
```
vs
```
echo /etc/containers/systemd/*.*
/etc/containers/systemd/busybox.image /etc/containers/systemd/centos.container /etc/containers/systemd/good.volume /etc/containers/systemd/kubeycentos.kube /etc/containers/systemd/podcentos.pod
```