### PR TITLE
Use search path for quadlets during validation

### DIFF
--- a/manifests/quadlet.pp
+++ b/manifests/quadlet.pp
@@ -179,7 +179,7 @@ define quadlets::quadlet (
   # We can only validate a directory of quadlet files and the file extension of the new
   # quadlet must be correct so we cannot test % directly :-(
   #
-  # Create a new tmp directory and copy the new quadlet and existing quadlet there to validate.
+  # Create a new tmp directory and copy the new quadlet to validate it.
   $_validate_cmd = $validate_quadlet ? {
     true    => epp('quadlets/validate_cmd.epp', {
       'quadlet' => $quadlet,

--- a/templates/validate_cmd.epp
+++ b/templates/validate_cmd.epp
@@ -7,9 +7,11 @@
     set -euo pipefail;
     d=$(mktemp -d);
     quad=$d/<%= $quadlet %>;
-    existing=(<%= $dest %>/*)
-    ((${#existing[@]})) && cp -- "${existing[@]}" $d/.
-    trap "rm $d/* ; rmdir $d" EXIT;
     cp % $quad;
-    env QUADLET_UNIT_DIRS=$d <%= $is_user ? { true => '/usr/lib/systemd/user-generators/podman-user-generator', default => '/usr/lib/systemd/system-generators/podman-system-generator' } %> --dryrun
+    trap "rm $quad ; rmdir $d" EXIT;
+    <%- if $is_user { -%>
+    env QUADLET_UNIT_DIRS=$d:<%= $dest %> /usr/lib/systemd/user-generators/podman-user-generator --dryrun
+    <%- } else  { -%>
+    env QUADLET_UNIT_DIRS=$d:<%= $dest %> /usr/lib/systemd/system-generators/podman-system-generator --dryrun
+    <%- } -%>
 '


### PR DESCRIPTION
#### Pull Request (PR) description

The `QUADLET_UNIT_DIRS` environment supports a search path of multiple directories that can used during the new quadlet's validation.

This is much better than what was being done before copying all the existing quadlets into one ephemeral location.

