### PR TITLE
Support setting subuid and subgid entries

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@
 fixtures:
   repositories:
     selinux_core: https://github.com/puppetlabs/puppetlabs-selinux_core
+    augeas_core: https://github.com/puppetlabs/puppetlabs-augeas_core
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib
     systemd: https://github.com/voxpupuli/puppet-systemd

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -470,6 +470,16 @@ quadlets::quadlet{ 'centos.container':
 }
 ```
 
+##### Specify subordinate start and size
+
+```puppet
+quadlets::user { 'quark':
+   name   => 'quark',
+   subuid => [10000, 15000],
+   subgid => [10000, 15000],
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `quadlets::user` defined type:
@@ -480,6 +490,8 @@ The following parameters are available in the `quadlets::user` defined type:
 * [`create_dir`](#-quadlets--user--create_dir)
 * [`manage_user`](#-quadlets--user--manage_user)
 * [`manage_linger`](#-quadlets--user--manage_linger)
+* [`subuid`](#-quadlets--user--subuid)
+* [`subgid`](#-quadlets--user--subgid)
 
 ##### <a name="-quadlets--user--user"></a>`user`
 
@@ -509,7 +521,7 @@ Default value: `undef`
 
 Data type: `Boolean`
 
-If true the directory for containers will be created at `$homedir/.config/contaners/systemd`.
+If true the directory for containers will be created at `$homedir/.config/containers/systemd`.
 
 Default value: `true`
 
@@ -528,6 +540,22 @@ Data type: `Boolean`
 If true `systemd --user` will be started for user.
 
 Default value: `true`
+
+##### <a name="-quadlets--user--subuid"></a>`subuid`
+
+Data type: `Optional[Tuple[Integer[1],Integer[1]]]`
+
+If defined as a pair of integers the user will have a subordintate user ID and a subordinate user ID count specified in `/etc/subuid`. Only one range per user is supported,
+
+Default value: `undef`
+
+##### <a name="-quadlets--user--subgid"></a>`subgid`
+
+Data type: `Optional[Tuple[Integer[1],Integer[1]]]`
+
+If defined as a pair of integers the user's group will have a subordintate group ID and a subordinate group ID count specified in `/etc/subgid`. Only one range per group is supported,
+
+Default value: `undef`
 
 ## Data types
 

--- a/lib/augeas/lenses/subids.aug
+++ b/lib/augeas/lenses/subids.aug
@@ -1,0 +1,45 @@
+
+(*
+  Subids — Augeas lens for /etc/subuid and /etc/subgid
+  ----------------------------------------------------
+  PURPOSE
+    Parse/write subordinate ID maps (shadow-utils): USER:START:COUNT
+  TREE
+    /files/etc/subuid/steve
+      start = "100000"
+      count = "65536"
+  NOTES
+    - Username is the node label
+    - Blank lines and full-line '#' comments are supported
+    - No trailing inline-comment support (ignored on write)
+    - Duplicates (same username multiple times) are allowed by lens;
+*)
+
+module Subids =
+
+autoload xfm
+
+let eol       = Util.eol
+let empty     = Util.empty
+let comment   = Util.comment
+let sep_colon = Util.del_str ":"
+
+let username_re = /[^:#\n]+/
+let num         = store /[0-9]+/
+
+let entry =
+  [ key username_re
+    . sep_colon
+    . [ label "start" . num ]
+    . sep_colon
+    . [ label "count" . num ]
+  ] . eol
+
+let lns = (comment | empty | entry)*
+
+let filter =
+     incl "/etc/subuid"
+  .  incl "/etc/subgid"
+
+let xfm = transform lns filter
+


### PR DESCRIPTION
#### Pull Request (PR) description

Particularly for service accounts it may be necessary to add or modify subordinate entries for a rootless podman user in `/etc/subuid` or `/etc/subgid`.

Example:

```puppet
Quadlets::Quadlet_user{ 'quark':
  user => {
    'name'   => 'quark',
    'subuid' => [10000,25000],
    'subgid' => [10000,25000],
  }
}
```

Will allocate a range of 25000 uids starting at 10000.
