### PR TITLE
Addition of quadlets.podman_version fact

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,17 @@ quadlets::quadlet{ 'my.pod':
 
 The end result is identical.
 
+## Quadlets Fact
+
+The podman version can be accessed via the `quadlets` fact.
+
+```
+facter quadlets
+{
+  podman_version => "5.4.0"
+}
+```
+
 ## Reference
 
 The reference of the quadlet module see [REFERENCE.md](REFERENCE.md)

--- a/lib/facter/quadlets.rb
+++ b/lib/facter/quadlets.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+#
+# Produce the version of podman (podman --version)
+# podman version 5.4.2
+
+Facter.add(:quadlets) do
+  @podman_cmd = Facter::Util::Resolution.which('podman')
+  confine { @podman_cmd }
+
+  setcode do
+    version = Facter::Core::Execution.execute(%(#{@podman_cmd} --version))[%r{^podman version (.*)$}, 1]
+    {
+      'podman_version' => version,
+    }
+  end
+end

--- a/spec/unit/quadlets_fact_spec.rb
+++ b/spec/unit/quadlets_fact_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'quadlets' do
+  before do
+    Facter.clear
+    allow(Facter::Util::Resolution).to receive(:which).with('podman').and_return('/usr/bin/podman')
+    allow(Facter::Core::Execution).to receive(:execute).with('/usr/bin/podman --version').and_return(podman_version_result)
+  end
+
+  context 'podman present' do
+    let(:podman_version_result) { "podman version 1.2.15\n" }
+
+    it 'returns valid fact' do
+      expect(Facter.fact('quadlets').value).to eq('podman_version' => '1.2.15')
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

A new fact is provided:

```
facter quadlets
{
  podman_version => "5.4.0"
}
```