### PR TITLE
allow for broader AddDevice type spec to include CDI devices

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -579,7 +579,7 @@ Alias of
 
 ```puppet
 Struct[Optional['AddCapability'] => Array[String[1],1],
-  Optional['AddDevice'] => Array[Stdlib::Absolutepath,1],
+  Optional['AddDevice'] => Array[String[1],1],
   Optional['AddHost'] => Array[String[1],1],
   Optional['Annotation'] => Array[String[1],1],
   Optional['AutoUpdate']  => Enum['registry','local'],

--- a/spec/defines/quadlet_spec.rb
+++ b/spec/defines/quadlet_spec.rb
@@ -77,6 +77,24 @@ describe 'quadlets::quadlet' do
 
           it { is_expected.to contain_file('/etc/containers/systemd/centos.container').without_validate_cmd }
         end
+
+        context 'with AddDevice using Container Device Interface' do
+          let(:params) do
+            base = super()
+            base.merge(
+              container_entry: base[:container_entry].merge(
+                'AddDevice' => ['nvidia.com/gpu=all']
+              )
+            )
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it 'adds AddDevice=nvidia.com/gpu=all to the quadlet file' do
+            is_expected.to contain_file('/etc/containers/systemd/centos.container').
+              with_content(%r{^AddDevice=nvidia\.com/gpu=all$})
+          end
+        end
       end
 
       context 'with a kube quadlet' do

--- a/types/unit/container.pp
+++ b/types/unit/container.pp
@@ -2,7 +2,7 @@
 # @see https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html
 type Quadlets::Unit::Container = Struct[
   Optional['AddCapability'] => Array[String[1],1],
-  Optional['AddDevice'] => Array[Stdlib::Absolutepath,1],
+  Optional['AddDevice'] => Array[String[1],1],
   Optional['AddHost'] => Array[String[1],1],
   Optional['Annotation'] => Array[String[1],1],
   Optional['AutoUpdate']  => Enum['registry','local'],


### PR DESCRIPTION
#### Pull Request (PR) description
The full path requirement for AddDevice does not allow for containers to add devices using the Container Device Interface definitions in '/etc/cdi'.  I scaled it back to simply requiring a String[1] as has been done for most other options.

See https://podman-desktop.io/docs/podman/gpu
