### PR TITLE
the correct selbool ends in _cgroup, not _group

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,7 +18,7 @@ class quadlets::config (
     }
   }
   if $facts['os']['selinux']['enabled'] and $selinux_container_manage_cgroup {
-    selboolean { 'container_manage_group':
+    selboolean { 'container_manage_cgroup':
       persistent => true,
       value      => on,
     }


### PR DESCRIPTION
#### Pull Request (PR) description
This is actually a bug I introduced a long time ago. The correct selinux boolean is 'container_manage_cgroup'

