### PR TITLE
Add `quadlets::users_hash` for hiera deploy

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -69,6 +69,7 @@ The following parameters are available in the `quadlets` class:
 * [`selinux_container_manage_cgroup`](#-quadlets--selinux_container_manage_cgroup)
 * [`purge_quadlet_dir`](#-quadlets--purge_quadlet_dir)
 * [`quadlets_hash`](#-quadlets--quadlets_hash)
+* [`users_hash`](#-quadlets--users_hash)
 
 ##### <a name="-quadlets--manage_package"></a>`manage_package`
 
@@ -182,7 +183,15 @@ Default value: `false`
 
 Data type: `Stdlib::CreateResources`
 
-a `Hash` of quadlets to deploy
+a `Hash` of `quadlets::quadlet` to deploy
+
+Default value: `{}`
+
+##### <a name="-quadlets--users_hash"></a>`users_hash`
+
+Data type: `Stdlib::CreateResources`
+
+a `Hash` of `quadlets::users` to deploy
 
 Default value: `{}`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,8 @@
 #   Should the directory for storing quadlet files be purged. This has no effect
 #   unless create_quadlet_dir is set to true.
 #
-# @param quadlets_hash a `Hash` of quadlets to deploy
+# @param quadlets_hash a `Hash` of `quadlets::quadlet` to deploy
+# @param users_hash a `Hash` of `quadlets::users` to deploy
 #
 # @example Set up Podman for quadlets
 #   include quadlets
@@ -44,6 +45,7 @@ class quadlets (
   Boolean $create_quadlet_users_dir = false,
   Boolean $purge_quadlet_dir = false,
   Stdlib::CreateResources $quadlets_hash = {},
+  Stdlib::CreateResources $users_hash = {},
 ) {
   $quadlet_dir = '/etc/containers/systemd'
   $quadlet_system_user_dir = '/etc/containers/systemd/users'
@@ -57,6 +59,12 @@ class quadlets (
 
   $quadlets_hash.each |$_n, $_v| {
     quadlets::quadlet { $_n:
+      * => $_v,
+    }
+  }
+
+  $users_hash.each |$_n, $_v| {
+    quadlets::user { $_n:
       * => $_v,
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -213,6 +213,29 @@ describe 'quadlets' do
             it { is_expected.to have_quadlets__quadlet_resource_count(2) }
           end
         end
+
+        context 'with users_hash as default' do
+          it { is_expected.to have_quadlets__user_resource_count(0) }
+        end
+
+        context 'with quadlet_users defined' do
+          let(:params) do
+            { users_hash: {
+              macron: {
+                group: 'leyen',
+                create_dir: true,
+              },
+              starmer: {
+                manage_user: true,
+                homedir: '/tmp/starmer',
+              },
+            } }
+          end
+
+          it { is_expected.to contain_quadlets__user('macron').with_group('leyen') }
+          it { is_expected.to contain_quadlets__user('starmer').with_manage_user(true) }
+          it { is_expected.to have_quadlets__user_resource_count(2) }
+        end
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description

The new parameter `users_hash` allows users suitable for running quadlets to be deployed with hiera data.

Also expand README with some other core examples following users of this module making mistakes.
