### PR TITLE
Fix service restart racing ahead of daemon-reload on .container file

### DIFF
--- a/manifests/quadlet.pp
+++ b/manifests/quadlet.pp
@@ -254,7 +254,7 @@ define quadlets::quadlet (
         File[$_quadlet_file] ~> Systemd::Daemon_reload[$quadlet]
       } else {
         File[$_quadlet_file] ~> Systemd::User_service[$_service]
-        Systemd::Daemon_reload[$quadlet] ~> Systemd::User_service[$_service]
+        Systemd::Daemon_reload[$quadlet] -> Systemd::User_service[$_service]
       }
     } else {
       service { $_service:
@@ -266,7 +266,7 @@ define quadlets::quadlet (
         File[$_quadlet_file] ~> Systemd::Daemon_reload[$quadlet]
       } else {
         File[$_quadlet_file] ~> Service[$_service]
-        Systemd::Daemon_reload[$quadlet] ~> Service[$_service]
+        Systemd::Daemon_reload[$quadlet] -> Service[$_service]
       }
     }
   }

--- a/spec/defines/quadlet_spec.rb
+++ b/spec/defines/quadlet_spec.rb
@@ -59,6 +59,18 @@ describe 'quadlets::quadlet' do
           end
 
           it { is_expected.to contain_service('centos.service').with_ensure(true) }
+
+          it 'notifies daemon_reload and service on file change' do
+            is_expected.to contain_file('/etc/containers/systemd/centos.container')
+              .that_notifies('Systemd::Daemon_reload[centos.container]')
+            is_expected.to contain_file('/etc/containers/systemd/centos.container')
+              .that_notifies('Service[centos.service]')
+          end
+
+          it 'orders daemon_reload before service restart' do
+            is_expected.to contain_systemd__daemon_reload('centos.container')
+              .that_comes_before('Service[centos.service]')
+          end
         end
 
         context 'with the container absent' do


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
I tried to be clear in the commit message:

     Fix service restart racing ahead of daemon-reload on .container file change
    
    When a quadlet file changes and active => true, two independent notify
    chains fire in parallel:
    
      File ~> Daemon_reload
      File ~> Service
    
    Because Puppet can schedule these in any order, the service refresh can
    be dispatched before systemctl daemon-reload completes. systemd then
    restarts the unit using the previously generated service definition,
    not the one derived from the updated .container file. The container
    either restarts with stale configuration or fails to start entirely.
    
    Fix by replacing the notify (Daemon_reload ~> Service) with a plain
    ordering constraint (Daemon_reload -> Service). The service still
    receives its refresh signal from File ~> Service, but cannot act on it
    until after the daemon-reload has finished. This preserves the single
    notification while guaranteeing the correct sequencing:
    
      File ~> Daemon_reload -> Service
      File ~>-----------------^ Service (refresh, held until above completes)


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
