### PR TITLE
Support Ubuntu 26.06

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -32,6 +32,12 @@
       ]
     },
     {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "26.04"
+      ]
+    },
+    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "9",


### PR DESCRIPTION
#### Pull Request (PR) description

Ubuntu 26.06 comes with podman >= 5 and so is supported.

